### PR TITLE
Add fix for 'width not divisible by 2'

### DIFF
--- a/bpsproxy/commands.py
+++ b/bpsproxy/commands.py
@@ -91,7 +91,7 @@ def get_commands_video_1(cfg, clargs, **kwargs):
         " -g 1"
         " -sn -an"
         " -vf colormatrix=bt601:bt709"
-        ' -vf scale=ceil(iw*{size}/2)*2:ceil(ih*{size}/2)*2'
+        " -vf scale=ceil(iw*{size}/2)*2:ceil(ih*{size}/2)*2"
         " {preset}"
         " '{path_o_1}'"
     )

--- a/bpsproxy/commands.py
+++ b/bpsproxy/commands.py
@@ -91,7 +91,7 @@ def get_commands_video_1(cfg, clargs, **kwargs):
         " -g 1"
         " -sn -an"
         " -vf colormatrix=bt601:bt709"
-        " -vf scale=iw*{size}:ih*{size}"
+        ' -vf scale=ceil(iw*{size}/2)*2:ceil(ih*{size}/2)*2'
         " {preset}"
         " '{path_o_1}'"
     )


### PR DESCRIPTION
Apparently the 4:2:0 subsampling requires even values for width and height: https://stackoverflow.com/a/29582287/8520828

Without this fix, this ffmpeg error could happen in some case:
```sh
[libx264] width not divisible by 2 (341x192)
```

PS: I installed the latest bpsproxy from pip, I did not try with the latest master branch.

![Screenshot from 2019-07-27 12-57-46](https://user-images.githubusercontent.com/6860637/61994482-af944180-b072-11e9-9b30-106160410224.png)
![Screenshot from 2019-07-27 12-59-49](https://user-images.githubusercontent.com/6860637/61994499-f6823700-b072-11e9-816a-92e7443e6fa2.png)


